### PR TITLE
fix: update zola config for version 0.22.0 compatibility

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -16,10 +16,10 @@ description = "The Digital HQ for Solana Builders in Thailand. Stake, Build, Ear
 # The default language
 default_language = "en"
 
+
 [markdown]
-# Highlight code blocks (Rust, TS, etc.)
-highlight_code = true
-highlight_theme = "base16-ocean-dark"
+[markdown.highlighting]
+theme = "base16-ocean-dark"
 
 [extra]
 # Custom variables


### PR DESCRIPTION
## Summary
This PR fixes the failing GitHub Actions build caused by a breaking change in Zola 0.22.0 syntax highlighting configuration.

## Changes
- Updated [docs/config.toml](cci:7://file:///Users/ozone/solana-thailand-genesis/docs/config.toml:0:0-0:0) to move syntax highlighting settings under the `[markdown.highlighting]` section.
- Removed deprecated fields `highlight_code` and `highlight_theme`.

## Verification
- Verified compatibility by running `zola build` locally, which now completes successfully.