### PR TITLE
fix: change highlighting theme to github-dark for zola 0.22 compatibility

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -19,7 +19,7 @@ default_language = "en"
 
 [markdown]
 [markdown.highlighting]
-theme = "base16-ocean-dark"
+theme = "github-dark"
 
 [extra]
 # Custom variables


### PR DESCRIPTION
## Summary
This PR fixes the deployment failures in GitHub Actions caused by breaking changes in Zola 0.22.0. 

## Problem
The previous build failed due to two issues in Zola 0.22.0:
1. **Config Syntax:** The `highlight_code` field is deprecated and moved to a new nested structure.
2. **Theme Availability:** The legacy `base16-ocean-dark` theme is not found in the new Zola 0.22.0 highlighting engine (Giallo).

## Changes
- **Configuration Update**: Migrated highlighting settings to the new `[markdown.highlighting]` table format.
- **Theme Migration**: Changed the syntax highlighting theme to `github-dark`, which is officially supported in Zola 0.22.0 and aligns with the project's dark aesthetic.

## Verification
- Verified by running `zola build` locally, which now completes successfully without any TOML or Theme errors.