### PR TITLE
fix(events): correct URL paths for event detail pages

### DIFF
--- a/docs/templates/events.html
+++ b/docs/templates/events.html
@@ -283,7 +283,9 @@ block #} {% endblock header %} {% block content %}
                 >
                 {% endif %}
 
-                <a href="{{ page.path }}" class="btn btn-outline">Details</a>
+                <a href="{{ get_url(path=page.path) }}" class="btn btn-outline"
+                    >Details</a
+                >
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Bug Fix

### Problem
The "Details" button on event cards was linking to incorrect URLs, missing the  base path:
- **Broken**: 
- **Correct**: 

This caused 404 errors when users tried to navigate from the events listing to event detail pages.

### Root Cause
The template was using  instead of , which bypasses Zola's URL generation that properly includes the base URL configured in .

### Solution
Updated the "Details" button in  to use :

```html
<!-- Before -->
<a href="{{ page.path }}" class="btn btn-outline">Details</a>

<!-- After -->
<a href="{{ get_url(path=page.path) }}" class="btn btn-outline">Details</a>
```

### Verification
- ✅ Other templates already use  correctly (base.html, index.html, event.html)
- ✅ This change ensures all internal navigation links include the proper base path
- ✅ No changes needed to external URLs (registration, recordings, etc.)

### Testing
After deployment, verify:
1. Event cards display correctly on /genesis/events/
2. "Details" button navigates to correct URLs (e.g., /genesis/events/road-to-mainnet-1-bangkok/)
3. No 404 errors when navigating between pages
4. Responsive design works on mobile devices