### PR TITLE
docs(recap): Road to Mainnet 2 (Bangkok) — address journey/roadmap drift, mark completed

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Our journey to empower the next generation of Solana builders in Thailand.
 
 ### 📅 Q2: On-chain Governance & Automation
 * **Road to Mainnet #1 (Apr 26) ✅ Completed:** Solana x AI Builders — Deep dive into Rust, AI Agents, and the Solana Ecosystem at ContributeDAO, Bangkok. ([Part 1](https://www.youtube.com/watch?v=vGhI2oxDKjI) / [Part 2 (Live)](https://www.youtube.com/watch?v=PEPDClvLngc))
-* **Road to Mainnet #2 (May 24):** Rust EP3 & AI Agent Micropayments with x402 at True Digital Park. ([Register on BeThere](https://bethere.solana-thailand.workers.dev/e/solana-x-ai-builders-the-road-to-mainnet-2-bangkok))
+* **Road to Mainnet #2 (May 24) ✅ Completed:** Rust EP3 & AI Agent Micropayments with x402 — the first BeThere deposit-backed event at True Digital Park. ([BeThere event page](https://bethere.solana-thailand.workers.dev/e/solana-x-ai-builders-the-road-to-mainnet-2-bangkok))
 * **BeThere Integration:** All future events now use [BeThere](https://bethere.solana-thailand.workers.dev/) — a deposit-backed, on-chain event platform.
 * **Discord Integration:** Automated role-syncing based on GitHub contribution history and Rank.
 * **Quest Expansion:** Introduction of Level 2+ specialized tracks (DeFi, Gaming, Infrastructure).

--- a/docs/content/events/road-to-mainnet-2-bangkok.md
+++ b/docs/content/events/road-to-mainnet-2-bangkok.md
@@ -6,7 +6,7 @@ weight = 4
 
 [extra]
 hide_header = true
-event_status = "upcoming"
+event_status = "completed"
 subtitle = "Rust EP3 & AI Agent Micropayments with x402"
 event_date = "Sunday, 24 May 2026"
 event_time = "1:00 PM – 3:00 PM"

--- a/docs/content/journey/_index.md
+++ b/docs/content/journey/_index.md
@@ -169,6 +169,19 @@ Solana Developer Thailand started as a passion project to bring together Rust de
 - Educational partnership with leading university
 - Onboarding the next generation of builders
 
+**April 26, 2026**
+**Road to Mainnet #1 — Rust, AI Agents & the Solana Ecosystem**
+- First session of the "Road to Mainnet" series, at ContributeDAO (CP Tower, Phaya Thai)
+- Four-speaker technical deep dive: Rust/AI/Gaming (Katopz), NFT with Metaplex (Golf), Ephemeral Rollups (Andy, Magicblock), APAC Ecosystem Spotlight (Chaerin, Solana Foundation)
+- Recordings: [Part 1](https://www.youtube.com/watch?v=vGhI2oxDKjI) / [Part 2 (Live)](https://www.youtube.com/watch?v=PEPDClvLngc)
+
+**May 24, 2026**
+**Road to Mainnet #2 — Rust EP3 & x402 Micropayments**
+- Second workshop in the Road to Mainnet series, at True Digital Park (TDPK)
+- First community event using [BeThere](https://bethere.solana-thailand.workers.dev/) deposit-backed registration (USDC escrow, refund-at-check-in, compressed NFT badges)
+- Two deep technical tracks: Rust EP3 (Katopz) and pay.sh — AI Agents with x402 Micropayments (Golf, ByteCat)
+- On-chain attendance metrics pending BeThere stats pull (see recap SOP 04)
+
 ---
 
 ## Join Our Community

--- a/docs/content/roadmap.md
+++ b/docs/content/roadmap.md
@@ -15,7 +15,7 @@ Our journey to empower the next generation of Solana builders in Thailand.
 
 ### Q2: On-chain Governance & Automation
 * **Road to Mainnet #1 (Apr 26) ✅ Completed:** Solana x AI Builders — Deep dive into Rust, AI Agents, and the Solana Ecosystem at ContributeDAO, Bangkok. ([Part 1](https://www.youtube.com/watch?v=vGhI2oxDKjI) / [Part 2 (Live)](https://www.youtube.com/watch?v=PEPDClvLngc))
-* **Road to Mainnet #2 (May 24):** Rust EP3 & AI Agent Micropayments with x402 — Powered by [BeThere](https://bethere.solana-thailand.workers.dev/) deposit-backed registration at True Digital Park. ([Register](https://bethere.solana-thailand.workers.dev/e/solana-x-ai-builders-the-road-to-mainnet-2-bangkok))
+* **Road to Mainnet #2 (May 24) ✅ Completed:** Rust EP3 & AI Agent Micropayments with x402 — the first [BeThere](https://bethere.solana-thailand.workers.dev/) deposit-backed event (USDC escrow, refund-at-check-in, compressed NFT badges) at True Digital Park. ([BeThere event page](https://bethere.solana-thailand.workers.dev/e/solana-x-ai-builders-the-road-to-mainnet-2-bangkok)) *(recording pending)*
 * **BeThere Integration:** All future events now use [BeThere](https://bethere.solana-thailand.workers.dev/) — a deposit-backed, on-chain event platform for no-show prevention and compressed NFT badges.
 * **Treasury Integration:** Migration of the community fund to a Multi-sig/DAO structure (evaluating Squads/Realms).
 * **Discord Integration:** Automated role-syncing based on GitHub contribution history and Rank.


### PR DESCRIPTION
## What

Runs **SOP 04 (Recap within 48h)** for **Road to Mainnet 2** (2026-05-24, TDPK) and addresses the public-site doc drift flagged by the DevRel OS state board — for **both Road to Mainnet 1 and Road to Mainnet 2** in one pass (per SOP 04 Section 6b: *batch the journey updates*).

## Changes

| File | Change |
|------|--------|
| `docs/content/journey/_index.md` | Add dated timeline entries for **Road to Mainnet 1 (Apr 26)** and **Road to Mainnet 2 (May 24)**. The public timeline was frozen at Jan 28 (MUICT) and had drifted past two completed events. |
| `docs/content/roadmap.md` | `Road to Mainnet 2 (May 24)` → Completed |
| `README.md` | Mirror the roadmap Q2 change |
| `docs/content/events/road-to-mainnet-2-bangkok.md` | `event_status`: `upcoming` → `completed` |

## State board impact

| Flag | Before | After |
|------|--------|-------|
| Road to Mainnet 1 — journey drift (CRIT) | missing | in timeline |
| Road to Mainnet 2 — recap overdue (CRIT) | 21d | recap_done |
| Road to Mainnet 2 — journey drift (WARN) | missing | in timeline |
| Road to Mainnet 2 — roadmap not done (WARN) | upcoming | completed |

Net: **2 critical / 4 warning → 0 critical / 2 warning** (the 2 remaining `recording_url empty` warnings are honest gaps, tracked separately).

## Honesty note — what is intentionally NOT in this PR

Road to Mainnet 2 attendance / deposit / cNFT **metrics** and the **recording** are deliberately excluded:

- **Metrics** depend on a live BeThere D1 stats pull (`bethere_pull_stats.sh`), which is blocked because the DevRel helper repo has no `.env` configured yet. Per SOP 04 rule 1 (*never fabricate numbers; on-chain metrics are verifiable*), cells are left empty rather than guessed.
- **Recording** has not shipped yet.

The event page is flipped to `completed` because the event genuinely happened 21 days ago — that is a fact, independent of the recording. The recording link will be added in a follow-up when published.

## Follow-ups (tracked in DevRel helper handover)

1. Wire `.env` (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `BETHERE_D1_DATABASE_ID`) in the helper repo → run `bethere_pull_stats.sh` → fill recap Section 1 + Section 4.
2. Confirm the USDC deposit amount from BeThere admin (YAML still has a `0` placeholder).
3. Ship recording → backfill `recording_url` on the event page + roadmap.
4. Assign a photographer for future events (photo capture was disorganized this round).
5. Post recap to FB / X / Discord / Email (SOP 04 Section 5) once stats are in.

Generated by DevRel OS SOP 04. Recap draft: `solana-thailand-devrel-helper/events/2026-05-24-road-to-mainnet-2-bangkok/recap.md`.
