### PR TITLE
docs: publish Road to Mainnet 2 recap to live site (journey + roadmap)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Our journey to empower the next generation of Solana builders in Thailand.
 
 ### 📅 Q2: On-chain Governance & Automation
 * **Road to Mainnet #1 (Apr 26) ✅ Completed:** Solana x AI Builders — Deep dive into Rust, AI Agents, and the Solana Ecosystem at ContributeDAO, Bangkok. ([Part 1](https://www.youtube.com/watch?v=vGhI2oxDKjI) / [Part 2 (Live)](https://www.youtube.com/watch?v=PEPDClvLngc))
-* **Road to Mainnet #2 (May 24):** Rust EP3 & AI Agent Micropayments with x402 at True Digital Park. ([Register on BeThere](https://bethere.solana-thailand.workers.dev/e/solana-x-ai-builders-the-road-to-mainnet-2-bangkok))
+* **Road to Mainnet #2 (May 24) ✅ Completed:** Rust EP3 & AI Agent Micropayments with x402 — the first BeThere deposit-backed event at True Digital Park. ([BeThere event page](https://bethere.solana-thailand.workers.dev/e/solana-x-ai-builders-the-road-to-mainnet-2-bangkok))
 * **BeThere Integration:** All future events now use [BeThere](https://bethere.solana-thailand.workers.dev/) — a deposit-backed, on-chain event platform.
 * **Discord Integration:** Automated role-syncing based on GitHub contribution history and Rank.
 * **Quest Expansion:** Introduction of Level 2+ specialized tracks (DeFi, Gaming, Infrastructure).

--- a/docs/content/events/road-to-mainnet-2-bangkok.md
+++ b/docs/content/events/road-to-mainnet-2-bangkok.md
@@ -6,7 +6,7 @@ weight = 4
 
 [extra]
 hide_header = true
-event_status = "upcoming"
+event_status = "completed"
 subtitle = "Rust EP3 & AI Agent Micropayments with x402"
 event_date = "Sunday, 24 May 2026"
 event_time = "1:00 PM – 3:00 PM"

--- a/docs/content/journey/_index.md
+++ b/docs/content/journey/_index.md
@@ -169,6 +169,19 @@ Solana Developer Thailand started as a passion project to bring together Rust de
 - Educational partnership with leading university
 - Onboarding the next generation of builders
 
+**April 26, 2026**
+**Road to Mainnet #1 — Rust, AI Agents & the Solana Ecosystem**
+- First session of the "Road to Mainnet" series, at ContributeDAO (CP Tower, Phaya Thai)
+- Four-speaker technical deep dive: Rust/AI/Gaming (Katopz), NFT with Metaplex (Golf), Ephemeral Rollups (Andy, Magicblock), APAC Ecosystem Spotlight (Chaerin, Solana Foundation)
+- Recordings: [Part 1](https://www.youtube.com/watch?v=vGhI2oxDKjI) / [Part 2 (Live)](https://www.youtube.com/watch?v=PEPDClvLngc)
+
+**May 24, 2026**
+**Road to Mainnet #2 — Rust EP3 & x402 Micropayments**
+- Second workshop in the Road to Mainnet series, at True Digital Park (TDPK)
+- First community event using [BeThere](https://bethere.solana-thailand.workers.dev/) deposit-backed registration (USDC escrow, refund-at-check-in, compressed NFT badges)
+- Two deep technical tracks: Rust EP3 (Katopz) and pay.sh — AI Agents with x402 Micropayments (Golf, ByteCat)
+- On-chain attendance metrics pending BeThere stats pull (see recap SOP 04)
+
 ---
 
 ## Join Our Community

--- a/docs/content/roadmap.md
+++ b/docs/content/roadmap.md
@@ -15,7 +15,7 @@ Our journey to empower the next generation of Solana builders in Thailand.
 
 ### Q2: On-chain Governance & Automation
 * **Road to Mainnet #1 (Apr 26) ✅ Completed:** Solana x AI Builders — Deep dive into Rust, AI Agents, and the Solana Ecosystem at ContributeDAO, Bangkok. ([Part 1](https://www.youtube.com/watch?v=vGhI2oxDKjI) / [Part 2 (Live)](https://www.youtube.com/watch?v=PEPDClvLngc))
-* **Road to Mainnet #2 (May 24):** Rust EP3 & AI Agent Micropayments with x402 — Powered by [BeThere](https://bethere.solana-thailand.workers.dev/) deposit-backed registration at True Digital Park. ([Register](https://bethere.solana-thailand.workers.dev/e/solana-x-ai-builders-the-road-to-mainnet-2-bangkok))
+* **Road to Mainnet #2 (May 24) ✅ Completed:** Rust EP3 & AI Agent Micropayments with x402 — the first [BeThere](https://bethere.solana-thailand.workers.dev/) deposit-backed event (USDC escrow, refund-at-check-in, compressed NFT badges) at True Digital Park. ([BeThere event page](https://bethere.solana-thailand.workers.dev/e/solana-x-ai-builders-the-road-to-mainnet-2-bangkok)) *(recording pending)*
 * **BeThere Integration:** All future events now use [BeThere](https://bethere.solana-thailand.workers.dev/) — a deposit-backed, on-chain event platform for no-show prevention and compressed NFT badges.
 * **Treasury Integration:** Migration of the community fund to a Multi-sig/DAO structure (evaluating Squads/Realms).
 * **Discord Integration:** Automated role-syncing based on GitHub contribution history and Rank.


### PR DESCRIPTION
Publishes the Road to Mainnet 2 (Bangkok) recap to the live site by merging `feature/03` into `main`. The `gh-pages` branch deploys from `main`, so this is the final step to make the journey timeline and roadmap changes visible to the public.

## Why
The recap work landed on `feature/03` only (via the recap pull request). The public site still shows the old content because `main` has not received it. This PR promotes those reviewed changes to `main` so the next `gh-pages` deploy publishes them.

## Changes (4 files, content/markdown only)
- `docs/content/journey/_index.md` — added dated timeline entries for both Road to Mainnet 1 and Road to Mainnet 2 (addresses both journey drifts in one pass)
- `docs/content/roadmap.md` — Road to Mainnet 2 marked as completed
- `docs/content/events/road-to-mainnet-2-bangkok.md` — event status flipped from upcoming to completed
- `README.md` — Road to Mainnet 2 roadmap line updated

## Verification
- Diff confirmed clean: 16 insertions, 3 deletions across 4 files
- No source code or template changes — content/markdown only
- Builds entirely on already-reviewed recap work; no new logic introduced
