### PR TITLE
docs: fix journey timeline by editing template, not ignored markdown

### DIFF
--- a/docs/content/journey/_index.md
+++ b/docs/content/journey/_index.md
@@ -169,19 +169,6 @@ Solana Developer Thailand started as a passion project to bring together Rust de
 - Educational partnership with leading university
 - Onboarding the next generation of builders
 
-**April 26, 2026**
-**Road to Mainnet #1 — Rust, AI Agents & the Solana Ecosystem**
-- First session of the "Road to Mainnet" series, at ContributeDAO (CP Tower, Phaya Thai)
-- Four-speaker technical deep dive: Rust/AI/Gaming (Katopz), NFT with Metaplex (Golf), Ephemeral Rollups (Andy, Magicblock), APAC Ecosystem Spotlight (Chaerin, Solana Foundation)
-- Recordings: [Part 1](https://www.youtube.com/watch?v=vGhI2oxDKjI) / [Part 2 (Live)](https://www.youtube.com/watch?v=PEPDClvLngc)
-
-**May 24, 2026**
-**Road to Mainnet #2 — Rust EP3 & x402 Micropayments**
-- Second workshop in the Road to Mainnet series, at True Digital Park (TDPK)
-- First community event using [BeThere](https://bethere.solana-thailand.workers.dev/) deposit-backed registration (USDC escrow, refund-at-check-in, compressed NFT badges)
-- Two deep technical tracks: Rust EP3 (Katopz) and pay.sh — AI Agents with x402 Micropayments (Golf, ByteCat)
-- On-chain attendance metrics pending BeThere stats pull (see recap SOP 04)
-
 ---
 
 ## Join Our Community

--- a/docs/templates/journey.html
+++ b/docs/templates/journey.html
@@ -799,6 +799,27 @@
             of builders
         </div>
     </div>
+
+    <div class="timeline-item">
+        <div class="timeline-date">April 26, 2026</div>
+        <div class="timeline-title">Road to Mainnet 1: Rust, AI Agents & the Solana Ecosystem</div>
+        <div class="timeline-desc">
+            First session of the Road to Mainnet series at ContributeDAO
+            (CP Tower, Phaya Thai) - a four-speaker deep dive into Rust, AI
+            agents, NFTs with Metaplex, and the Solana ecosystem.
+        </div>
+    </div>
+
+    <div class="timeline-item">
+        <div class="timeline-date">May 24, 2026</div>
+        <div class="timeline-title">Road to Mainnet 2: Rust EP3 & x402 Micropayments</div>
+        <div class="timeline-desc">
+            Second workshop in the Road to Mainnet series at True Digital
+            Park (TDPK) - Rust EP3 and AI agent micropayments with x402,
+            the first BeThere deposit-backed event (USDC escrow, compressed
+            NFT badges).
+        </div>
+    </div>
 </section>
 
 <!-- Community Statistics -->


### PR DESCRIPTION
Fixes the journey timeline, which was still missing the Road to Mainnet events on the live site even after the earlier live-publish PR merged.

## Root cause
The `journey.html` template **hardcodes the entire Event Timeline as static HTML**. The body of `journey/_index.md` is never rendered (only its `[extra]` front matter is used). The prior recap work added the Road to Mainnet 1 and 2 entries to the markdown body, which had no effect — the live timeline still ended at the Mahidole workshop.

## Changes (2 files)
- `docs/templates/journey.html` — add two `timeline-item` blocks (date / title / desc) for Road to Mainnet 1 (April 26, 2026, ContributeDAO) and Road to Mainnet 2 (May 24, 2026, True Digital Park), placed after the Mahidole entry, matching the existing structure exactly.
- `docs/content/journey/_index.md` — remove the now-dead RTM prose from the body (it was never rendered; keeping it caused confusion about where the timeline comes from).

## Verification (pre-merge)
Built locally with `zola build` and confirmed the rendered `journey/index.html` timeline now lists both events in order:
- January 28, 2026 — Mahidole University ICT Workshop
- April 26, 2026 — Road to Mainnet 1: Rust, AI Agents & the Solana Ecosystem
- May 24, 2026 — Road to Mainnet 2: Rust EP3 & x402 Micropayments

No other pages or templates were touched; the roadmap and event pages were already correct from the previous deploy.
