### PR TITLE
fix: mark RTM#2 completed, replace broken Golf slides link

### DIFF
--- a/docs/content/events/road-to-mainnet-1-bangkok.md
+++ b/docs/content/events/road-to-mainnet-1-bangkok.md
@@ -45,7 +45,8 @@ speakers = [
 | Speaker | Topic | Slides |
 |---------|-------|--------|
 | Katopz | Rust, AI & Gaming (Ep. 2) | [Google Slides](https://docs.google.com/presentation/d/1HikZEH_mt31sbV93ps-1EiQEJGO6v7RuXT5a4QsRhds/edit?usp=sharing) |
-| Golf | NFT Engine Workshop | [Google Slides](https://docs.google.com/presentation/d/e/2PACX-1vS-t310yXERTs3HeZ1bwGK_i4rSRa3fYdN6899g1YO2e81kOWs8EJ4iRy36d3iiELYuyTYMjS3--Fdd/pub?start=false&loop=false&delayms=3000) |
+| Golf | NFT Engine Workshop | _Slides being republished_ |
+<!-- TODO(need-to-fix): Golf's slides returned 410 Gone. Old URL was https://docs.google.com/presentation/d/e/2PACX-1vS-t310yXERTs3HeZ1bwGK_i4rSRa3fYdN6899g1YO2e81kOWs8EJ4iRy36d3iiELYuyTYMjS3--Fdd/pub?start=false&loop=false&delayms=3000 — replace when re-published. -->
 | Chaerin | APAC Ecosystem Spotlight | [Google Drive](https://drive.google.com/file/d/15YBHFHpIROSTxOWRMzzipHpGDnhLkEWd/view?usp=sharing) |
 
 ---

--- a/docs/content/events/road-to-mainnet-2-bangkok.md
+++ b/docs/content/events/road-to-mainnet-2-bangkok.md
@@ -14,8 +14,6 @@ countdown_target = "2026-05-24T13:00:00+07:00"
 venue_name = "True Digital Park (TDPK)"
 venue_location = "Building Pegasus, 6th Floor, Meeting Room 6.11"
 poster_image = "road-to-mainnet-2-poster.jpg"
-registration_url = "https://bethere.solana-thailand.workers.dev/e/solana-x-ai-builders-the-road-to-mainnet-2-bangkok"
-registration_deadline = "Limited Seats (18 Onsite)"
 perks = [
     "Hands-on Workshops",
     "Compressed NFT Badge (On-chain Proof of Attendance)",
@@ -38,30 +36,9 @@ Join the second workshop in the **"Road to Mainnet"** series. This session level
 
 ---
 
-### Registration via BeThere
+### Registration
 
-We're using **[BeThere](https://bethere.solana-thailand.workers.dev/)** — a deposit-backed event platform on Solana. Put down a small deposit to reserve your spot. Show up, get refunded. Simple.
-
-**[Reserve Your Spot on BeThere](https://bethere.solana-thailand.workers.dev/e/solana-x-ai-builders-the-road-to-mainnet-2-bangkok)**
-
-You can also join the waitlist on [Luma](https://luma.com/05f1306f) — the team will send the BeThere payment link via email to confirm your spot.
-
----
-
-### Registration Rules
-
-**Onsite (Refundable Deposit):**
-- Register on [Luma](https://luma.com/05f1306f) to join the waitlist
-- The team will send the **BeThere deposit link** via email to confirm your spot
-- **First 18** who complete the deposit get confirmed — **fully refunded at check-in**
-- No-show = deposit forfeited to the organizer
-
-**Online:**
-- Opens after onsite spots are full (free)
-- Or grab **Online Early Bird (500 THB, non-refundable)** for guaranteed access
-
-**First Come, First Served:**
-- 16 seats with tables for laptops (remaining are chairs around the room). Come early to pick your spot!
+Registration was handled via **[BeThere](https://bethere.solana-thailand.workers.dev/)** — a deposit-backed event platform on Solana. A refundable deposit reserved each onsite spot, with deposits returned at check-in.
 
 ---
 
@@ -70,7 +47,7 @@ You can also join the waitlist on [Luma](https://luma.com/05f1306f) — the team
 - **Rust EP3**: เจาะลึก Rust สำหรับ Game Development — Level up from EP1 & EP2
 - **x402 Micropayments**: สร้าง AI Agents ที่ทำธุรกรรมได้จริงด้วยมาตรฐานใหม่บน Solana
 - **On-chain Proof**: รับ compressed NFT Badge หลังเข้าร่วมงาน (ผ่านระบบ BeThere)
-- **Hands-on Workshop**: เตรียม Notebook มาด้วย!
+- **Hands-on Workshop**: ทำ Workshop ไปพร้อมกันที่หน้างาน
 
 ---
 
@@ -89,11 +66,11 @@ You can also join the waitlist on [Luma](https://luma.com/05f1306f) — the team
 
 ---
 
-### Important Notes
+### What Attendees Received
 
-- **Bring Your Laptop**: สำหรับร่วม Workshop / Required for hands-on session
-- **Deposit System**: มัดจำผ่านระบบ BeThere (คืนเงินเต็มจำนวนเมื่อเช็คอินที่หน้างาน)
-- **NFT Badge**: รับ digital badge บน Solana เป็นหลักฐานการเข้าร่วม
+- **Hands-on Workshop**: ทำ Workshop ไปพร้อมกันที่หน้างาน
+- **NFT Badge**: digital badge บน Solana เป็นหลักฐานการเข้าร่วม
+- **Deposit Refunded**: คืนเงินมัดจำเต็มจำนวนผ่านระบบ BeThere เมื่อเช็คอิน
 
 ---
 

--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -18,25 +18,24 @@ endblock header %} {% block content %}
 
 <section class="main-content">
     <div class="grid">
-        <!-- Upcoming May 2026 Event Card -->
-        <div class="glass-card event-highlight">
-            <span class="status-badge active" style="margin-bottom: 1rem"
-                >Upcoming: May 24</span
+        <!-- Completed May 2026 Event Card -->
+        <div class="glass-card event-highlight" style="opacity: 0.85">
+            <span
+                class="status-badge"
+                style="
+                    margin-bottom: 1rem;
+                    background: rgba(153, 69, 255, 0.08);
+                    border-color: var(--solana-purple);
+                    color: var(--solana-purple);
+                "
+                >Completed: May 24</span
             >
             <h3>Solana x AI Builders: The Road to Mainnet #2</h3>
             <p>
-                Rust EP3 & AI Agent Micropayments with x402. Deposit-backed
-                registration via BeThere at True Digital Park.
+                Rust EP3 & AI Agent Micropayments with x402 at True Digital
+                Park. Recordings coming soon.
             </p>
             <div style="display: flex; gap: 0.75rem; flex-wrap: wrap">
-                <a
-                    href="https://bethere.solana-thailand.workers.dev/e/solana-x-ai-builders-the-road-to-mainnet-2-bangkok"
-                    class="btn btn-primary"
-                    style="flex: 1; min-width: 140px; text-align: center"
-                    target="_blank"
-                    rel="noopener"
-                    >Register on BeThere</a
-                >
                 <a
                     href="{{ get_url(path='events/road-to-mainnet-2-bangkok') }}"
                     class="btn btn-outline"
@@ -44,8 +43,8 @@ endblock header %} {% block content %}
                         flex: 1;
                         min-width: 140px;
                         text-align: center;
-                        border-color: var(--solana-green);
-                        color: var(--solana-green);
+                        border-color: var(--solana-purple);
+                        color: var(--solana-purple);
                     "
                     >Event Details</a
                 >


### PR DESCRIPTION
## Context

Road to Mainnet #2 (May 24) was marked \`completed\` in frontmatter by PR #25/#26, but the **homepage and event-page body still read as upcoming**, advertising registration via BeThere for a past event. This PR closes that drift.

## Changes

### Homepage (\`templates/index.html\`)
- RTM#2 card: \`Upcoming: May 24\` → \`Completed: May 24\`
- Faded style (\`opacity: 0.85\`) matching RTM#1
- Removed **Register on BeThere** CTA (no longer valid)
- Single **Event Details** button (purple)

### RTM#2 event page (\`content/events/road-to-mainnet-2-bangkok.md\`)
- Removed dead \`registration_url\` / \`registration_deadline\` frontmatter (template already gates on \`event_status != completed\`)
- Replaced **Registration via BeThere** + **Registration Rules** sections with a single past-tense **Registration** note
- Renamed **Important Notes** → **What Attendees Received** (no more "bring your laptop" / "deposit system" pre-event instructions)
- Fixed "เตรียม Notebook มาด้วย!" → "ทำ Workshop ไปพร้อมกันที่หน้างาน"

### RTM#1 event page (\`content/events/road-to-mainnet-1-bangkok.md\`)
- Golf NFT Engine Workshop slides link returned **410 Gone** → replaced with `_Slides being republished_` + TODO comment preserving the original URL for restoration

## Validation
- ✅ \`zola check\` — **0 broken links** (was 1)
- ✅ \`zola serve\` hot-reloaded all 3 files cleanly
- Previewed live at http://127.0.0.1:1111/

## Follow-ups (not in this PR)
- RTM#2 recordings / slides / photos — add once available
- Restore Golf RTM#1 slides link when re-published (see TODO in file)