### PR TITLE
feat: add Road to Mainnet #3 (Jun 20) upcoming event

### DIFF
--- a/docs/content/events/road-to-mainnet-3-bangkok.md
+++ b/docs/content/events/road-to-mainnet-3-bangkok.md
@@ -1,0 +1,94 @@
++++
+title = "Solana x AI Builders: The Road to Mainnet #3 (Bangkok)"
+description = "Rust EP4 'Hello Latent Space' — the third workshop in the Road to Mainnet series."
+template = "event.html"
+weight = 3
+
+[extra]
+hide_header = true
+event_status = "upcoming"
+subtitle = "Rust EP4: Hello Latent Space"
+event_date = "Saturday, 20 June 2026"
+event_time = "1:00 PM – 3:00 PM"
+countdown_target = "2026-06-20T13:00:00+07:00"
+venue_name = "True Digital Park (TDPK)"
+venue_location = "Building Pegasus, 6th Floor, Meeting Room 6.11"
+# TODO(verify): create the BeThere event with this exact slug so the link resolves.
+registration_url = "https://bethere.solana-thailand.workers.dev/e/solana-x-ai-builders-the-road-to-mainnet-3-bangkok"
+registration_deadline = "Limited Seats (18 Onsite)"
+perks = [
+    "Hands-on Workshops",
+    "Compressed NFT Badge (On-chain Proof of Attendance)",
+    "Deposit Refunded on Check-in"
+]
+speakers = [
+    { name = "Katopz", role = "Rust EP4: Hello Latent Space", role_type = "primary", org = "Solana Developer Thailand Leader", image = "katopz.jpg", social_links = { twitter = "https://x.com/katopz/" } },
+    { name = "Luke Dflow", role = "TBD", role_type = "secondary", org = "Dflow", image = "logo.png" }
+]
++++
+
+### About This Event
+
+ซีรีส์ "Road to Mainnet" รอบที่ 3 — ยกระดับเทคนิคไปอีกขั้น
+
+Join the third workshop in the **"Road to Mainnet"** series. Two focused tracks:
+
+- **Rust EP4: Hello Latent Space** — โดย Katopz (Solana Developer Thailand Leader)
+- **TBD** — โดย Luke Dflow (Dflow)
+
+---
+
+### Registration via BeThere
+
+We're using **[BeThere](https://bethere.solana-thailand.workers.dev/)** — a deposit-backed event platform on Solana. Put down a small deposit to reserve your spot. Show up, get refunded. Simple.
+
+**[Reserve Your Spot on BeThere](https://bethere.solana-thailand.workers.dev/e/solana-x-ai-builders-the-road-to-mainnet-3-bangkok)**
+
+---
+
+### Registration Rules
+
+**Onsite (Refundable Deposit):**
+- Put down a refundable deposit to confirm your spot
+- **First 18** who complete the deposit get confirmed — **fully refunded at check-in**
+- No-show = deposit forfeited to the organizer
+
+**First Come, First Served:**
+- 16 seats with tables for laptops (remaining are chairs around the room). Come early to pick your spot!
+
+---
+
+### Highlights
+
+- **Rust EP4: Hello Latent Space**: เจาะลึก Rust EP4 — Level up from EP1, EP2 & EP3
+- **On-chain Proof**: รับ compressed NFT Badge หลังเข้าร่วมงาน (ผ่านระบบ BeThere)
+- **Hands-on Workshop**: เตรียม Notebook มาด้วย!
+
+---
+
+### Agenda
+
+- **13:00 – 13:10**: Opening & Welcome
+- **13:10 – 14:00**: Rust EP4: Hello Latent Space by Katopz
+- **14:00 – 14:50**: TBD by Luke Dflow
+- **14:50 – 15:00**: Q&A, Networking
+
+---
+
+### Location
+
+**True Digital Park (TDPK)**, ตึกเพกาซัส ชั้น 6 ห้อง Meeting Room 6.11
+
+---
+
+### Important Notes
+
+- **Bring Your Laptop**: สำหรับร่วม Workshop / Required for hands-on session
+- **Deposit System**: มัดจำผ่านระบบ BeThere (คืนเงินเต็มจำนวนเมื่อเช็คอินที่หน้างาน)
+- **NFT Badge**: รับ digital badge บน Solana เป็นหลักฐานการเข้าร่วม
+
+---
+
+### Inquiries
+
+Join our [Discord](https://discord.gg/PGbUgNmsns) for more information.

--- a/docs/content/roadmap.md
+++ b/docs/content/roadmap.md
@@ -16,6 +16,7 @@ Our journey to empower the next generation of Solana builders in Thailand.
 ### Q2: On-chain Governance & Automation
 * **Road to Mainnet #1 (Apr 26) ✅ Completed:** Solana x AI Builders — Deep dive into Rust, AI Agents, and the Solana Ecosystem at ContributeDAO, Bangkok. ([Part 1](https://www.youtube.com/watch?v=vGhI2oxDKjI) / [Part 2 (Live)](https://www.youtube.com/watch?v=PEPDClvLngc))
 * **Road to Mainnet #2 (May 24) ✅ Completed:** Rust EP3 & AI Agent Micropayments with x402 — the first [BeThere](https://bethere.solana-thailand.workers.dev/) deposit-backed event (USDC escrow, refund-at-check-in, compressed NFT badges) at True Digital Park. ([BeThere event page](https://bethere.solana-thailand.workers.dev/e/solana-x-ai-builders-the-road-to-mainnet-2-bangkok)) *(recording pending)*
+* **Road to Mainnet #3 (Jun 20) 🔜 Upcoming:** Rust EP4 “Hello Latent Space” by Katopz, plus a session by Luke Dflow (Dflow). Same BeThere deposit-backed registration at True Digital Park. ([BeThere event page](https://bethere.solana-thailand.workers.dev/e/solana-x-ai-builders-the-road-to-mainnet-3-bangkok))
 * **BeThere Integration:** All future events now use [BeThere](https://bethere.solana-thailand.workers.dev/) — a deposit-backed, on-chain event platform for no-show prevention and compressed NFT badges.
 * **Treasury Integration:** Migration of the community fund to a Multi-sig/DAO structure (evaluating Squads/Realms).
 * **Discord Integration:** Automated role-syncing based on GitHub contribution history and Rank.

--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -18,6 +18,40 @@ endblock header %} {% block content %}
 
 <section class="main-content">
     <div class="grid">
+        <!-- Upcoming June 2026 Event Card -->
+        <div class="glass-card event-highlight">
+            <span class="status-badge active" style="margin-bottom: 1rem"
+                >Upcoming: Jun 20</span
+            >
+            <h3>Solana x AI Builders: The Road to Mainnet #3</h3>
+            <p>
+                Rust EP4 "Hello Latent Space" & more. Deposit-backed
+                registration via BeThere at True Digital Park.
+            </p>
+            <div style="display: flex; gap: 0.75rem; flex-wrap: wrap">
+                <a
+                    href="https://bethere.solana-thailand.workers.dev/e/solana-x-ai-builders-the-road-to-mainnet-3-bangkok"
+                    class="btn btn-primary"
+                    style="flex: 1; min-width: 140px; text-align: center"
+                    target="_blank"
+                    rel="noopener"
+                    >Register on BeThere</a
+                >
+                <a
+                    href="{{ get_url(path='events/road-to-mainnet-3-bangkok') }}"
+                    class="btn btn-outline"
+                    style="
+                        flex: 1;
+                        min-width: 140px;
+                        text-align: center;
+                        border-color: var(--solana-green);
+                        color: var(--solana-green);
+                    "
+                    >Event Details</a
+                >
+            </div>
+        </div>
+
         <!-- Completed May 2026 Event Card -->
         <div class="glass-card event-highlight" style="opacity: 0.85">
             <span


### PR DESCRIPTION
## Context

Adds the third installment of the "Road to Mainnet" series as an upcoming event. Same format as #2 (TDPK venue, BeThere deposit-backed registration, 1–3 PM), with two tracks.

> **Stacked on PR #28** (`feature/04_rtm2_completed_cleanup`). Merge #28 first, then retarget this PR to `main`.

## Event Details

| Field | Value |
|---|---|
| Title | Solana x AI Builders: The Road to Mainnet #3 (Bangkok) |
| Date | **Saturday, 20 June 2026**, 1:00 PM – 3:00 PM |
| Venue | True Digital Park (TDPK), Pegasus Bldg, 6F, Room 6.11 |
| Registration | BeThere (deposit-backed) |
| Speaker 1 | **Katopz** — Rust EP4: "Hello Latent Space" (primary) |
| Speaker 2 | **Luke Dflow** (Dflow) — TBD (secondary) |

## Changes

### New file: `content/events/road-to-mainnet-3-bangkok.md`
Full event page (About, Registration via BeThere, Registration Rules, Highlights, Agenda, Location, Important Notes, Inquiries). Frontmatter:
- `event_status = "upcoming"`, `weight = 3` (sorts first)
- `countdown_target = "2026-06-20T13:00:00+07:00"` (live countdown)
- `registration_url` following the established BeThere slug pattern

### `templates/index.html`
RTM#3 becomes the hero **"Upcoming: Jun 20"** card (green active badge + BeThere register button). RTM#2 and RTM#1 now sit below it as faded completed cards.

### `content/roadmap.md`
Added a `Road to Mainnet #3 (Jun 20) 🔜 Upcoming` entry under Q2.

### `templates/events.html`
No change needed — the events listing template auto-renders RTM#3 with an "Upcoming" badge and Register button based on frontmatter.

## Validation
- ✅ `zola check` — 0 broken links, 7 pages build cleanly
- ✅ `zola serve` hot-reloaded; previewed at http://127.0.0.1:1111/

## ⚠️ Follow-ups / verification needed (before event)

- [ ] **BeThere event**: create the BeThere event with slug `solana-x-ai-builders-the-road-to-mainnet-3-bangkok` so the registration link resolves (currently follows the #2 pattern — see `TODO(verify)` in the file)
- [ ] **Luke Dflow**: confirm org (`Dflow`?), Twitter/handle, and topic — currently `role = "TBD"`
- [ ] **Speaker photo for Luke**: no image in `static/` — using `logo.png` placeholder; add `luke-dflow.jpg` when available
- [ ] **Poster**: no `road-to-mainnet-3-poster.jpg` yet — the event page renders fine without it (poster is optional in the template)

## Preview URLs
- Homepage: http://127.0.0.1:1111/
- Event page: http://127.0.0.1:1111/events/road-to-mainnet-3-bangkok/
- Events list: http://127.0.0.1:1111/events/