### PR TITLE
feat: add Weekly Online Series page (calendar + BeThere sessions)

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -26,3 +26,7 @@ theme = "github-dark"
 author = "Solana Thailand Core Team"
 github_repo = "https://github.com/solana-thailand/genesis"
 discord_url = "https://discord.gg/PGbUgNmsns"
+# Google Calendar embed URL for the weekly online series.
+# Format: https://calendar.google.com/calendar/embed?src=<CALENDAR_ID>&ctz=Asia/Bangkok
+# Leave empty to show a "calendar coming" placeholder on the online-events page.
+online_calendar_embed = ""

--- a/docs/content/online-events/_index.md
+++ b/docs/content/online-events/_index.md
@@ -1,0 +1,22 @@
++++
+title = "Weekly Online Series"
+description = "Weekly online builder sessions on Solana — recurring talks and hands-on workshops. Join from anywhere."
+template = "online-events.html"
+weight = 1
+sort_by = "weight"
+
+[extra]
+hide_header = true
+
+# Upcoming online sessions. Each renders as a card with a BeThere register button.
+# Add new sessions here as they are scheduled.
+# Fields: title, topic, date_label, registration_url (BeThere)
+sessions = [
+    { title = "Intro to Vibing on Solana", topic = "Onboarding session for new builders", date_label = "Weekly · Online", registration_url = "https://bethere.solana-thailand.workers.dev/e/intro-to-vibing-on-solana" },
+    { title = "Solana in Latent Space (Part 1)", topic = "Deep dive into AI × Solana", date_label = "Weekly · Online", registration_url = "https://bethere.solana-thailand.workers.dev/e/solana-in-latent-space-part-1" }
+]
++++
+
+A weekly online series for Solana builders — recurring talks, demos, and hands-on sessions you can join from anywhere. Each session uses **[BeThere](https://bethere.solana-thailand.workers.dev/)** for deposit-backed registration (refund at check-in, compressed NFT badge as proof of attendance).
+
+Sessions appear on the calendar below as they're scheduled. Subscribe so you never miss one.

--- a/docs/templates/base.html
+++ b/docs/templates/base.html
@@ -40,6 +40,8 @@
       <ul class="nav-links">
         <li><a href="{{ get_url(path='events') }}" {% if current_path=='/events/' %}class="active" {% endif
             %}>Events</a></li>
+        <li><a href="{{ get_url(path='online-events') }}" {% if current_path=='/online-events/' %}class="active" {% endif
+            %}>Online</a></li>
         <li><a href="{{ get_url(path='quests') }}" {% if current_path=='/quests/' %}class="active" {% endif
             %}>Quests</a></li>
         <li><a href="{{ get_url(path='rules') }}" {% if current_path=='/rules/' %}class="active" {% endif

--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -181,6 +181,40 @@ endblock header %} {% block content %}
             </div>
         </div>
 
+        <!-- Weekly Online Series Card -->
+        <div class="glass-card event-highlight">
+            <span class="status-badge active" style="margin-bottom: 1rem"
+                >Weekly · Online</span
+            >
+            <h3>Weekly Online Builder Series</h3>
+            <p>
+                Recurring online talks & hands-on sessions. Deposit-backed
+                registration via BeThere — join from anywhere.
+            </p>
+            <div style="display: flex; gap: 0.75rem; flex-wrap: wrap">
+                <a
+                    href="{{ get_url(path='online-events') }}"
+                    class="btn btn-primary"
+                    style="flex: 1; min-width: 140px; text-align: center"
+                    >View Schedule</a
+                >
+                <a
+                    href="https://bethere.solana-thailand.workers.dev/"
+                    class="btn btn-outline"
+                    style="
+                        flex: 1;
+                        min-width: 140px;
+                        text-align: center;
+                        border-color: var(--solana-green);
+                        color: var(--solana-green);
+                    "
+                    target="_blank"
+                    rel="noopener"
+                    >All Sessions</a
+                >
+            </div>
+        </div>
+
         <div class="glass-card">
             <h3>Rules of Engagement</h3>
             <p>

--- a/docs/templates/online-events.html
+++ b/docs/templates/online-events.html
@@ -1,0 +1,203 @@
+{% extends "base.html" %} {% block header %} {# Hidden - rendered inside content
+block #} {% endblock header %} {% block extra_head %}
+<style>
+    .online-hero {
+        text-align: center;
+        padding: 4rem 0 2rem;
+    }
+    .online-hero h1 {
+        font-size: 3rem;
+        margin-bottom: 1rem;
+    }
+    .online-hero .lead {
+        font-size: 1.2rem;
+        color: var(--text-secondary);
+        max-width: 720px;
+        margin: 0 auto 2rem;
+        line-height: 1.7;
+        font-weight: 300;
+    }
+    .online-section-title {
+        font-size: 1.5rem;
+        margin: 2.5rem 0 1.25rem;
+    }
+    .online-intro {
+        font-size: 1rem;
+        color: var(--text-secondary);
+        max-width: 720px;
+        margin: 0 auto 1rem;
+        line-height: 1.7;
+    }
+
+    /* Calendar embed */
+    .calendar-frame {
+        position: relative;
+        width: 100%;
+        border: 1px solid var(--glass-border);
+        border-radius: 12px;
+        overflow: hidden;
+        background: var(--glass-bg);
+    }
+    .calendar-frame iframe {
+        display: block;
+        width: 100%;
+        height: 600px;
+        border: 0;
+    }
+    .calendar-placeholder {
+        padding: 3rem 1.5rem;
+        text-align: center;
+        color: var(--text-dim);
+        line-height: 1.7;
+    }
+    .calendar-placeholder code {
+        color: var(--solana-green);
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        background: rgba(20, 241, 149, 0.06);
+        padding: 0.15rem 0.4rem;
+        border-radius: 4px;
+    }
+
+    /* Session cards */
+    .sessions-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+        gap: 1.5rem;
+    }
+    .session-card {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        padding: 1.5rem;
+    }
+    .session-card .badge {
+        align-self: flex-start;
+        font-size: 0.7rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        padding: 0.25rem 0.75rem;
+        border-radius: 4px;
+        background: rgba(20, 241, 149, 0.08);
+        border: 1px solid var(--solana-green);
+        color: var(--solana-green);
+    }
+    .session-card h3 {
+        font-size: 1.2rem;
+        color: #fff;
+        margin: 0.25rem 0 0;
+        line-height: 1.3;
+    }
+    .session-card .topic {
+        font-size: 0.9rem;
+        color: var(--text-secondary);
+        line-height: 1.5;
+        flex: 1;
+    }
+    .session-card .meta {
+        font-size: 0.8rem;
+        color: var(--text-dim);
+        font-family: var(--font-mono);
+    }
+    .session-card .btn {
+        margin-top: 0.75rem;
+        text-align: center;
+    }
+
+    @media (max-width: 768px) {
+        .online-hero {
+            padding: 2rem 0 1rem;
+        }
+        .online-hero h1 {
+            font-size: 2.25rem;
+        }
+        .online-hero .lead {
+            font-size: 1.05rem;
+        }
+        .calendar-frame iframe {
+            height: 450px;
+        }
+        .sessions-grid {
+            grid-template-columns: 1fr;
+        }
+    }
+</style>
+{% endblock extra_head %} {% block content %}
+<section class="online-hero">
+    <h1>{{ section.title }}</h1>
+    {% if section.description %}
+    <p class="lead">{{ section.description }}</p>
+    {% endif %} {% if section.content and section.content | trim | length > 0 %}
+    <div class="online-intro">{{ section.content | safe }}</div>
+    {% endif %}
+    <div class="cta-group" style="justify-content: center">
+        {% if config.extra.online_calendar_embed %}
+        <a
+            href="{{ config.extra.online_calendar_embed }}"
+            class="btn btn-outline"
+            target="_blank"
+            rel="noopener"
+            >Subscribe (Google Calendar)</a
+        >
+        {% endif %}
+        <a
+            href="https://bethere.solana-thailand.workers.dev/"
+            class="btn btn-primary"
+            target="_blank"
+            rel="noopener"
+            >All Sessions on BeThere</a
+        >
+    </div>
+</section>
+
+<!-- Sessions -->
+{% if section.extra.sessions %}
+<h2 class="online-section-title">Upcoming Sessions</h2>
+<div class="sessions-grid">
+    {% for s in section.extra.sessions %}
+    <div class="session-card glass-card">
+        <span class="badge">Online</span>
+        <h3>{{ s.title }}</h3>
+        <p class="topic">{{ s.topic }}</p>
+        <p class="meta">{{ s.date_label }}</p>
+        <a
+            href="{{ s.registration_url }}"
+            class="btn btn-primary"
+            target="_blank"
+            rel="noopener"
+            >Register on BeThere</a
+        >
+    </div>
+    {% endfor %}
+</div>
+{% endif %}
+
+<!-- Calendar -->
+<h2 class="online-section-title">Calendar</h2>
+{% if config.extra.online_calendar_embed %}
+<div class="calendar-frame">
+    <iframe
+        src="{{ config.extra.online_calendar_embed }}"
+        title="Solana Thailand Weekly Online Series Calendar"
+        loading="lazy"
+    ></iframe>
+</div>
+{% else %}
+<div class="calendar-frame">
+    <div class="calendar-placeholder">
+        <p>📅 Calendar coming soon.</p>
+        <p>
+            In the meantime, grab a spot in an upcoming session above, or join
+            our
+            <a
+                href="https://discord.gg/PGbUgNmsns"
+                target="_blank"
+                rel="noopener"
+                >Discord</a
+            >
+            for the latest schedule.
+        </p>
+    </div>
+</div>
+{% endif %} {% endblock content %}


### PR DESCRIPTION
## Context

The community runs a **weekly online series** (recurring talks/hands-on sessions) separate from the in-person "Road to Mainnet" events. This adds a dedicated page + homepage entry for it.

> **Stacked on PR #29** (`feature/05_rtm3_upcoming`). Merge #28 → #29 → retarget this to `main`.

## What was added

### New page: `/online-events/` (template: `online-events.html`)
- Hero with CTAs: **Subscribe to calendar** + **All Sessions on BeThere**
- **Session cards** driven by a `sessions` array in frontmatter — each renders title, topic, date label, and a BeThere register button. Currently:
  - Intro to Vibing on Solana → `…/e/intro-to-vibing-on-solana`
  - Solana in Latent Space (Part 1) → `…/e/solana-in-latent-space-part-1`
- **Google Calendar embed** iframe — auto-renders the weekly schedule. Falls back to a clean placeholder when the embed URL is not set.

### Config (`config.toml`)
- New `online_calendar_embed` slot (empty) with usage comment. **One value to fill** when the calendar link is provided.

### Nav (`base.html`)
- Added **Online** link after **Events**.

### Homepage (`index.html`)
- Added a **"Weekly Online Builder Series"** card with "View Schedule" + "All Sessions" buttons.

## Validation
- ✅ `zola build` — 7 pages, 5 sections, no errors
- ✅ `zola check` — 0 broken links
- ✅ Hot-reloaded and previewed at http://127.0.0.1:1111/online-events/

## ⚠️ To activate the calendar (one config change)
When you share the Google Calendar link, paste the **embed URL** into `docs/config.toml`:
```toml
online_calendar_embed = "https://calendar.google.com/calendar/embed?src=CALENDAR_ID&ctz=Asia/Bangkok"
```
The page will then show the live calendar + a "Subscribe" button automatically.

## Follow-ups
- [ ] Provide Google Calendar embed URL (I have no cross-session memory — need it each time)
- [ ] Confirm weekly day/time (ICT) so I can add it to the session card labels / a recurring note
- [ ] Add more sessions to the `sessions` array in `online-events/_index.md` as they are scheduled